### PR TITLE
Add Jest tests for phone number formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cydmodulareslanding",
+  "version": "1.0.0",
+  "description": "Una landing page moderna y responsive para una empresa especializada en fabricación e instalación de muebles a medida en aglomerado.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -234,6 +234,11 @@ function formatPhoneNumber(phone) {
     return phone;
 }
 
+// Export for testing in Node environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.formatPhoneNumber = formatPhoneNumber;
+}
+
 // ===== FUNCIONES DE TRACKING =====
 
 // Función para trackear eventos

--- a/tests/formatPhoneNumber.test.js
+++ b/tests/formatPhoneNumber.test.js
@@ -1,0 +1,18 @@
+const { formatPhoneNumber } = require('../script.js');
+
+describe('formatPhoneNumber', () => {
+  test('formats 10-digit Colombian numbers', () => {
+    expect(formatPhoneNumber('3001234567')).toBe('+57 300 123 4567');
+    expect(formatPhoneNumber('(301) 234-5678')).toBe('+57 301 234 5678');
+  });
+
+  test('formats numbers with country code 57', () => {
+    expect(formatPhoneNumber('573001234567')).toBe('+57 300 123 4567');
+    expect(formatPhoneNumber('+57 3021234567')).toBe('+57 302 123 4567');
+  });
+
+  test('returns input unchanged for invalid lengths', () => {
+    expect(formatPhoneNumber('12345')).toBe('12345');
+    expect(formatPhoneNumber('57300123456')).toBe('57300123456');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test suite for `formatPhoneNumber`
- export `formatPhoneNumber` for use in tests
- configure npm test script to run Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a6fd7c808326add7e0b12778ab0e