### PR TITLE
Fix space in hero subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
                 <span class="hero-title-accent">que Transforman tu Espacio</span>
             </h1>
             <p class="hero-subtitle">
-                Fabricamos e instalamos cocinas, closets, escritorios y muebles para oficina en aglomerado de alta calidad. 
+                Fabricamos e instalamos cocinas, closets, escritorios y muebles para oficina en aglomerado de alta calidad.
                 Personalización total, durabilidad garantizada y precios competitivos.
             </p>
             <div class="hero-buttons">


### PR DESCRIPTION
## Summary
- remove trailing whitespace in hero subtitle line
- ensure text reads `escritorios y muebles`

## Testing
- `git diff --color`


------
https://chatgpt.com/codex/tasks/task_e_6883a6eaf9b88326979c5def84fedd4b